### PR TITLE
[feat] Add possibility to use services except serveo.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,17 @@ Run beeing in project path.
     >`pyenv local reverse_forwarding`
 - Run:
     >`python3 app.py`
+
+This will create ssh tunnel to your local machine from serveo.net service and
+use the obtained url to generate external urls.
+
+As an alternative, you can use any reverse proxy you want in combination with
+this utility. To do so first run the reverse proxy and obtain the external url.
+For example with ngrok reverse proxy you may use the following command:
+
+    >`ngrok http 9090  # or whatever else port you want`
+
+After that run reverse_forwarding app with obtained external url as commandline
+parameter:
+
+    >`python3 app.py --url http://external.url.example.com`

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import logging.config
 
@@ -106,10 +107,23 @@ def run_app(proxy_link):
 
 
 def main():
+    parser = argparse.ArgumentParser(description='''
+        Accept requests from remote services
+        on your local machine during debugging
+    ''')
+    parser.add_argument('--url', metavar='URL', type=str,
+                        help='External URL, if already obtained',
+                        default=None, required=False)
+    args = parser.parse_args()
+
     proxy_link = Array('c', 50)
 
-    port_forwarding_proc = Process(target=run_port_forwarding, args=(proxy_link,))
-    port_forwarding_proc.start()
+    if args.url:
+        proxy_link.value = bytes(args.url, 'utf-8')
+    else:
+        port_forwarding_proc = Process(target=run_port_forwarding,
+                                       args=(proxy_link,))
+        port_forwarding_proc.start()
 
     app_proc = Process(target=run_app, args=(proxy_link,))
     app_proc.start()


### PR DESCRIPTION
Lately serveo.net shown itself to be unreliable and not forwarding
requests made to it. At the same time ngrok.io shows much better
reliablity.

This commit adds possibility to provide external URL obtained from
different service to the reverse forwarding and use it.

Example usage:

```bash
    # in terminal 1
    term1 $ ./ngrok http 9090
    # in terminal 2
    python app.py --url <url obtained from ngrok>
```